### PR TITLE
Refactor `sapling_crypto::keys` API to be more like `orchard::keys`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Added
+- `sapling_crypto::keys`:
+  - `ProofAuthorizingKey`
+  - `impl From<&ProofAuthorizingKey> for NullifierDerivingKey`
+
+### Changed
+- `sapling_crypto::keys`:
+  - `ExpandedSpendingKey.nsk` now has type `ProofAuthorizingKey`.
+  - `ProofGenerationKey.nsk` now has type `ProofAuthorizingKey`.
+
 ## [0.1.0] - 2024-01-26
 The crate has been completely rewritten. See [`zcash/librustzcash`] for the
 history of this rewrite.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this library adheres to Rust's notion of
   - `ExpandedSpendingKey.nsk` now has type `ProofAuthorizingKey`.
   - `ProofGenerationKey.nsk` now has type `ProofAuthorizingKey`.
 
+### Removed
+- `sapling_crypto::keys`:
+  - `ViewingKey` (use `FullViewingKey` instead).
+
 ## [0.1.0] - 2024-01-26
 The crate has been completely rewritten. See [`zcash/librustzcash`] for the
 history of this rewrite.

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -25,6 +25,9 @@ use self::constants::{
 #[cfg(test)]
 use group::ff::PrimeFieldBits;
 
+#[cfg(test)]
+use crate::keys::ProofAuthorizingKey;
+
 mod constants;
 mod ecc;
 mod pedersen_hash;
@@ -190,7 +193,9 @@ impl Circuit<bls12_381::Scalar> for Spend {
             // Witness nsk as bits
             let nsk = boolean::field_into_boolean_vec_le(
                 cs.namespace(|| "nsk"),
-                self.proof_generation_key.as_ref().map(|k| k.nsk),
+                self.proof_generation_key
+                    .as_ref()
+                    .map(|k| k.nsk.to_scalar()),
             )?;
 
             // NB: We don't ensure that the bit representation of nsk
@@ -658,7 +663,7 @@ fn test_input_circuit_with_bls12_381() {
 
         let proof_generation_key = ProofGenerationKey {
             ak: SpendValidatingKey::fake_random(&mut rng),
-            nsk: jubjub::Fr::random(&mut rng),
+            nsk: ProofAuthorizingKey::random(&mut rng),
         };
 
         let viewing_key = proof_generation_key.to_viewing_key();
@@ -833,7 +838,7 @@ fn test_input_circuit_with_bls12_381_external_test_vectors() {
 
         let proof_generation_key = ProofGenerationKey {
             ak: SpendValidatingKey::fake_random(&mut rng),
-            nsk: jubjub::Fr::random(&mut rng),
+            nsk: ProofAuthorizingKey::random(&mut rng),
         };
 
         let viewing_key = proof_generation_key.to_viewing_key();
@@ -984,7 +989,7 @@ fn test_output_circuit_with_bls12_381() {
             randomness: jubjub::Fr::random(&mut rng),
         };
 
-        let nsk = jubjub::Fr::random(&mut rng);
+        let nsk = ProofAuthorizingKey::random(&mut rng);
         let ak = SpendValidatingKey::fake_random(&mut rng);
 
         let proof_generation_key = ProofGenerationKey { ak, nsk };

--- a/src/zip32.rs
+++ b/src/zip32.rs
@@ -14,7 +14,7 @@ use zip32::{ChainCode, ChildIndex, DiversifierIndex, Scope};
 use std::io::{self, Read, Write};
 use std::ops::AddAssign;
 
-use super::{Diversifier, NullifierDerivingKey, PaymentAddress, ViewingKey};
+use super::{Diversifier, NullifierDerivingKey, PaymentAddress};
 use crate::keys::ProofAuthorizingKey;
 use crate::{
     constants::PROOF_GENERATION_KEY_GENERATOR,
@@ -37,7 +37,7 @@ pub fn sapling_address(
     j: DiversifierIndex,
 ) -> Option<PaymentAddress> {
     dk.diversifier(j)
-        .and_then(|d_j| fvk.vk.to_payment_address(d_j))
+        .and_then(|d_j| fvk.to_payment_address(d_j))
 }
 
 /// Search the diversifier space starting at diversifier index `j` for
@@ -50,7 +50,7 @@ pub fn sapling_find_address(
     j: DiversifierIndex,
 ) -> Option<(DiversifierIndex, PaymentAddress)> {
     let (j, d_j) = dk.find_diversifier(j)?;
-    fvk.vk.to_payment_address(d_j).map(|addr| (j, addr))
+    fvk.to_payment_address(d_j).map(|addr| (j, addr))
 }
 
 /// Returns the payment address corresponding to the smallest valid diversifier
@@ -93,16 +93,14 @@ pub fn sapling_derive_internal_fvk(
         jubjub::Fr::from_bytes_wide(&PrfExpand::SAPLING_ZIP32_INTERNAL_NSK.with(i.as_bytes()));
     let r = PrfExpand::SAPLING_ZIP32_INTERNAL_DK_OVK.with(i.as_bytes());
     // PROOF_GENERATION_KEY_GENERATOR = \mathcal{H}^Sapling
-    let nk_internal = NullifierDerivingKey(PROOF_GENERATION_KEY_GENERATOR * i_nsk + fvk.vk.nk.0);
+    let nk_internal = NullifierDerivingKey(PROOF_GENERATION_KEY_GENERATOR * i_nsk + fvk.nk.0);
     let dk_internal = DiversifierKey(r[..32].try_into().unwrap());
     let ovk_internal = OutgoingViewingKey(r[32..].try_into().unwrap());
 
     (
         FullViewingKey {
-            vk: ViewingKey {
-                ak: fvk.vk.ak.clone(),
-                nk: nk_internal,
-            },
+            ak: fvk.ak.clone(),
+            nk: nk_internal,
             ovk: ovk_internal,
         },
         dk_internal,
@@ -534,9 +532,7 @@ impl std::cmp::PartialEq for ExtendedFullViewingKey {
             && self.parent_fvk_tag == rhs.parent_fvk_tag
             && self.child_index == rhs.child_index
             && self.chain_code == rhs.chain_code
-            && self.fvk.vk.ak == rhs.fvk.vk.ak
-            && self.fvk.vk.nk == rhs.fvk.vk.nk
-            && self.fvk.ovk == rhs.fvk.ovk
+            && self.fvk == rhs.fvk
             && self.dk == rhs.dk
     }
 }
@@ -709,16 +705,16 @@ impl DiversifiableFullViewingKey {
     /// This API is provided so that nullifiers for change notes can be correctly computed.
     pub fn to_nk(&self, scope: Scope) -> NullifierDerivingKey {
         match scope {
-            Scope::External => self.fvk.vk.nk,
-            Scope::Internal => self.derive_internal().fvk.vk.nk,
+            Scope::External => self.fvk.nk,
+            Scope::Internal => self.derive_internal().fvk.nk,
         }
     }
 
     /// Derives an incoming viewing key corresponding to this full viewing key.
     pub fn to_ivk(&self, scope: Scope) -> SaplingIvk {
         match scope {
-            Scope::External => self.fvk.vk.ivk(),
-            Scope::Internal => self.derive_internal().fvk.vk.ivk(),
+            Scope::External => self.fvk.ivk(),
+            Scope::Internal => self.derive_internal().fvk.ivk(),
         }
     }
 
@@ -937,9 +933,7 @@ mod tests {
         // Check value -> bytes -> parsed round trip.
         let dfvk_bytes = dfvk.to_bytes();
         let dfvk_parsed = DiversifiableFullViewingKey::from_bytes(&dfvk_bytes).unwrap();
-        assert_eq!(dfvk_parsed.fvk.vk.ak, dfvk.fvk.vk.ak);
-        assert_eq!(dfvk_parsed.fvk.vk.nk, dfvk.fvk.vk.nk);
-        assert_eq!(dfvk_parsed.fvk.ovk, dfvk.fvk.ovk);
+        assert_eq!(dfvk_parsed.fvk, dfvk.fvk);
         assert_eq!(dfvk_parsed.dk, dfvk.dk);
 
         // Check bytes -> parsed -> bytes round trip.
@@ -1651,14 +1645,14 @@ mod tests {
         }
 
         for (xfvk, tv) in xfvks.iter().zip(test_vectors.iter()) {
-            assert_eq!(xfvk.fvk.vk.ak.to_bytes(), tv.ak);
-            assert_eq!(xfvk.fvk.vk.nk.0.to_bytes(), tv.nk);
+            assert_eq!(xfvk.fvk.ak.to_bytes(), tv.ak);
+            assert_eq!(xfvk.fvk.nk.0.to_bytes(), tv.nk);
 
             assert_eq!(xfvk.fvk.ovk.0, tv.ovk);
             assert_eq!(xfvk.dk.0, tv.dk);
             assert_eq!(xfvk.chain_code.as_bytes(), &tv.c);
 
-            assert_eq!(xfvk.fvk.vk.ivk().to_repr().as_ref(), tv.ivk);
+            assert_eq!(xfvk.fvk.ivk().to_repr().as_ref(), tv.ivk);
 
             let mut ser = vec![];
             xfvk.write(&mut ser).unwrap();
@@ -1695,17 +1689,14 @@ mod tests {
             }
 
             let internal_xfvk = xfvk.derive_internal();
-            assert_eq!(internal_xfvk.fvk.vk.ak.to_bytes(), tv.ak);
-            assert_eq!(internal_xfvk.fvk.vk.nk.0.to_bytes(), tv.internal_nk);
+            assert_eq!(internal_xfvk.fvk.ak.to_bytes(), tv.ak);
+            assert_eq!(internal_xfvk.fvk.nk.0.to_bytes(), tv.internal_nk);
 
             assert_eq!(internal_xfvk.fvk.ovk.0, tv.internal_ovk);
             assert_eq!(internal_xfvk.dk.0, tv.internal_dk);
             assert_eq!(internal_xfvk.chain_code.as_bytes(), &tv.c);
 
-            assert_eq!(
-                internal_xfvk.fvk.vk.ivk().to_repr().as_ref(),
-                tv.internal_ivk
-            );
+            assert_eq!(internal_xfvk.fvk.ivk().to_repr().as_ref(), tv.internal_ivk);
 
             let mut ser = vec![];
             internal_xfvk.write(&mut ser).unwrap();


### PR DESCRIPTION
Closes #118.