### PR TITLE
Derive `{PartialOrd, Ord}` for `note::Nullifier`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Added
+- `impl {PartialOrd, Ord} for sapling_crypto::note::Nullifier`
+
 ## [0.1.2] - 2024-03-08
 ### Added
 - `sapling_crypto::zip32::IncomingViewingKey`

--- a/src/note/nullifier.rs
+++ b/src/note/nullifier.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 /// Typesafe wrapper for nullifier values.
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Nullifier(pub [u8; 32]);
 
 impl fmt::Debug for Nullifier {


### PR DESCRIPTION
For parity with `orchard` & use in an in-memory wallet.