### PR TITLE
Release sapling-crypto version 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+## [0.2.0] - 2024-08-12
+
+### Changed
+- Updated to `incrementalmerkletree` version `0.6`.
+
 ## [0.1.3] - 2024-03-25
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -625,12 +625,14 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "incrementalmerkletree"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "361c467824d4d9d4f284be4b2608800839419dccc4d4608f28345237fe354623"
+checksum = "75346da3bd8e3d8891d02508245ed2df34447ca6637e343829f8d08986e9cde2"
 dependencies = [
  "either",
  "proptest",
+ "rand",
+ "rand_core",
 ]
 
 [[package]]
@@ -1271,7 +1273,7 @@ dependencies = [
 
 [[package]]
 name = "sapling-crypto"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "aes",
  "bellman",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sapling-crypto"
-version = "0.1.3"
+version = "0.2.0"
 authors = [
     "Sean Bowe <sean@electriccoin.co>",
     "Jack Grigg <jack@electriccoin.co>",
@@ -50,7 +50,7 @@ tracing = "0.1"
 
 # Note Commitment Trees
 bitvec = "1"
-incrementalmerkletree = { version = "0.5", features = ["legacy-api"] }
+incrementalmerkletree = { version = "0.6", features = ["legacy-api"] }
 
 # Note encryption
 zcash_note_encryption = { version = "0.4", features = ["pre-zip-212"] }
@@ -72,7 +72,7 @@ zip32 = "0.1"
 [dev-dependencies]
 chacha20poly1305 = "0.10"
 criterion = "0.4"
-incrementalmerkletree = { version = "0.5", features = ["legacy-api", "test-dependencies"] }
+incrementalmerkletree = { version = "0.6", features = ["legacy-api", "test-dependencies"] }
 proptest = "1"
 rand_xorshift = "0.3"
 


### PR DESCRIPTION
This is a maintenance release to upgrade the `incrementalmerkletree` dependency to version 0.6.