### PR TITLE
Broaden `Authorization`s from `SpendDescriptionV5::into_spend_description`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this library adheres to Rust's notion of
   `sapling_crypto::keys::EphemeralSecretKey`, matching the existing public APIs
   that expose it.
 
+### Changed
+- `sapling_crypto::bundle::SpendDescriptionV5::into_spend_description` now
+  supports any `Authorization` for which the `SpendDescription` itself is fully
+  authorized.
+
 ## [0.3.0] - 2024-10-02
 
 ### Changed

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -298,12 +298,15 @@ impl SpendDescriptionV5 {
         Self { cv, nullifier, rk }
     }
 
-    pub fn into_spend_description(
+    pub fn into_spend_description<A>(
         self,
         anchor: bls12_381::Scalar,
         zkproof: GrothProofBytes,
         spend_auth_sig: redjubjub::Signature<SpendAuth>,
-    ) -> SpendDescription<Authorized> {
+    ) -> SpendDescription<A>
+    where
+        A: Authorization<SpendProof = GrothProofBytes, AuthSig = redjubjub::Signature<SpendAuth>>,
+    {
         SpendDescription {
             cv: self.cv,
             anchor,


### PR DESCRIPTION
This enables the method to be used with bundles that have spend auth signatures and proofs, but not yet binding signatures.