### PR TITLE
Fix `OutputProver::prepare_circuit` API to be usable outside the crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Fixed
+- `sapling_crypto::prover::OutputProver::prepare_circuit` now takes `esk` as an
+  `sapling_crypto::keys::EphemeralSecretKey`, matching the existing public APIs
+  that expose it.
+
 ## [0.3.0] - 2024-10-02
 
 ### Changed

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -369,7 +369,7 @@ impl PreparedOutputInfo {
 
         // Prepare the circuit that will be used to construct the proof.
         let zkproof = Pr::prepare_circuit(
-            encryptor.esk().0,
+            encryptor.esk(),
             self.note.recipient(),
             self.note.rcm(),
             self.note.value(),

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -7,6 +7,7 @@ use rand_core::RngCore;
 use crate::{
     bundle::GrothProofBytes,
     circuit::{self, GROTH_PROOF_SIZE},
+    keys::EphemeralSecretKey,
     value::{NoteValue, ValueCommitTrapdoor},
     MerklePath,
 };
@@ -56,7 +57,7 @@ pub trait OutputProver {
     ///
     /// Returns `None` if `diversifier` is not a valid Sapling diversifier.
     fn prepare_circuit(
-        esk: jubjub::Fr,
+        esk: &EphemeralSecretKey,
         payment_address: PaymentAddress,
         rcm: jubjub::Fr,
         value: NoteValue,
@@ -136,7 +137,7 @@ impl OutputProver for OutputParameters {
     type Proof = Proof<Bls12>;
 
     fn prepare_circuit(
-        esk: jubjub::Fr,
+        esk: &EphemeralSecretKey,
         payment_address: PaymentAddress,
         rcm: jubjub::Fr,
         value: NoteValue,
@@ -153,7 +154,7 @@ impl OutputProver for OutputParameters {
             value_commitment_opening: Some(value_commitment_opening),
             payment_address: Some(payment_address),
             commitment_randomness: Some(rcm),
-            esk: Some(esk),
+            esk: Some(esk.0),
         }
     }
 
@@ -179,6 +180,7 @@ pub mod mock {
     use crate::{
         bundle::GrothProofBytes,
         circuit::{self, ValueCommitmentOpening, GROTH_PROOF_SIZE},
+        keys::EphemeralSecretKey,
         value::{NoteValue, ValueCommitTrapdoor},
         Diversifier, MerklePath, PaymentAddress, ProofGenerationKey, Rseed,
     };
@@ -235,7 +237,7 @@ pub mod mock {
         type Proof = GrothProofBytes;
 
         fn prepare_circuit(
-            esk: jubjub::Fr,
+            esk: &EphemeralSecretKey,
             payment_address: PaymentAddress,
             rcm: jubjub::Fr,
             value: NoteValue,
@@ -248,7 +250,7 @@ pub mod mock {
                 }),
                 payment_address: Some(payment_address),
                 commitment_randomness: Some(rcm),
-                esk: Some(esk),
+                esk: Some(esk.0),
             }
         }
 


### PR DESCRIPTION
The public APIs that produced `esk` all used the `EphemeralSecretKey` type, but that could only be converted to a `jubjub::Scalar` inside the crate. We now use the type-safe wrapper consistently.