### PR TITLE
Make `ExtractedNoteCommitment` APIs public

### DIFF
--- a/src/note/commitment.rs
+++ b/src/note/commitment.rs
@@ -78,7 +78,8 @@ impl ExtractedNoteCommitment {
         self.0.to_repr()
     }
 
-    pub(crate) fn inner(&self) -> jubjub::Base {
+    /// Returns the inner [`jubjub::Base`] value
+    pub fn inner(&self) -> jubjub::Base {
         self.0
     }
 }


### PR DESCRIPTION
### TODO:

Implement `serde::{Serialize, Deserialize}` for these types and remove the `serde_helpers` module in `zebra-chain`.


## Motivation

We want to de-duplicate types across zebra-chain, sapling-crypto, orchard, and librustzcash, starting with the note commitment types.

It's currently not possible to get the inner `jubjub::Base` from an `ExtractedNoteCommitment` type in this crate from `zebra-consensus`.

Closes #163

## Solution

- Makes the `inner()` methods on `ExtractedNoteCommitment` public