### PR TITLE
Expose spend-auth signing and verification accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Added
+- `SpendAuthorizingKey::sign` signs a message with the unrandomized
+  spend-authorizing key, for non-transaction signatures.
+- `SpendValidatingKey::to_verification_key` returns the unrandomized
+  verification key.
+
 ## [0.7.0] - 2026-04-21
 
 ### Changed

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -27,8 +27,7 @@ use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 use zcash_note_encryption::EphemeralKeyBytes;
 use zcash_spec::PrfExpand;
 
-#[cfg(all(feature = "circuit", test))]
-use rand_core::RngCore;
+use rand_core::{CryptoRng, RngCore};
 
 /// Errors that can occur in the decoding of Sapling spending keys.
 #[derive(Debug)]
@@ -147,6 +146,20 @@ impl SpendAuthorizingKey {
     pub fn randomize(&self, randomizer: &jubjub::Scalar) -> redjubjub::SigningKey<SpendAuth> {
         self.0.randomize(randomizer)
     }
+
+    /// Signs a message with this spend-authorizing key, without randomization.
+    ///
+    /// This is intended for non-transaction signatures (such as binding a UFVK
+    /// to the account's spending authority) where no per-spend randomizer is
+    /// applied. For spend authorization signatures, use [`Self::randomize`] with
+    /// the spend's randomizer and sign with the resulting key.
+    pub fn sign<R: RngCore + CryptoRng>(
+        &self,
+        rng: R,
+        msg: &[u8],
+    ) -> redjubjub::Signature<SpendAuth> {
+        self.0.sign(rng, msg)
+    }
 }
 
 /// A key used to validate spend authorization signatures.
@@ -222,6 +235,15 @@ impl SpendValidatingKey {
     /// Randomizes this spend validating key with the given `randomizer`.
     pub fn randomize(&self, randomizer: &jubjub::Scalar) -> redjubjub::VerificationKey<SpendAuth> {
         self.0.randomize(randomizer)
+    }
+
+    /// Returns the unrandomized verification key.
+    ///
+    /// This is the base verification key corresponding to this spend validating
+    /// key, without any randomizer applied. Use [`Self::randomize`] to obtain a
+    /// randomized verification key for spend-auth signature verification.
+    pub fn to_verification_key(&self) -> redjubjub::VerificationKey<SpendAuth> {
+        self.0
     }
 }
 


### PR DESCRIPTION
## Motivation

Downstream consumers (notably `zcash_keys` in librustzcash) need to sign and verify non-transaction messages with spend-authorizing keys. For example, the proposed UFVK binding signature in `zcash_keys` signs a UFVK's canonical encoding with the account's `UnifiedSpendingKey` to detect tampering of the stored UFVK in a wallet database (audit finding COR-1649).

Currently, the signing and verification primitives are only accessible through the `randomize` path, which applies a per-spend randomizer. For non-transaction signatures, no randomizer is needed, but there is no public way to sign with the unrandomized key or to obtain the unrandomized verification key.

## Changes

- `SpendAuthorizingKey::sign` signs a message with the unrandomized spend-authorizing key, delegating to the inner `redjubjub::SigningKey`.
- `SpendValidatingKey::to_verification_key` returns the unrandomized `redjubjub::VerificationKey`, enabling verification of non-spend signatures.

Both are pure delegation methods with no new logic. The existing `randomize` path is unchanged.

[COR-1649](https://linear.app/zodl/issue/COR-1649/issue-b-receive-address-derivation-trusts-an-unvalidated-database)

Co-Authored-By: Claude <noreply@anthropic.com>